### PR TITLE
Add support for CustomTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ enabling navigation between step definitions and gherkin steps when using cucumb
 - [x] Indexing of step definitions for better performance
 - [x] Support "constant expressions" in step definition names
 - [x] Find step definitions in libraries with attached sources
-- [ ] Support for Java annotations
+- [x] Navigate custom types and java type annotations*
+- [ ] Support for Java annotations  
+- [ ] Warn on non-matching custom types/java annotations definition
+  
+_(*cannot resolve the exact regex, so the navigation works, but it will not warn you if your input doesn't match the regex of the type)_
 
 ## Development
 
@@ -25,9 +29,10 @@ The plugin depends on:
 
 To setup the development environment, follow these steps:
 
-1. `git clone https://github.com/vbmacher/intellij-cucumber-scala.git`
-2. Open the project in IDEA
-3. Wait until `gradle-intellij-plugin` downloads Idea SDK and required plugins.
+1. configure`jdk-11`
+2. `git clone https://github.com/vbmacher/intellij-cucumber-scala.git`
+3. Open the project in IDEA
+4. Wait until `gradle-intellij-plugin` downloads Idea SDK and required plugins.
 
 Now you can build this plugin with `build` task.
 

--- a/cucumber-scala/src/main/scala/com/github/vbmacher/intellij/cucumber/scala/steps/ScStepDefinition.scala
+++ b/cucumber-scala/src/main/scala/com/github/vbmacher/intellij/cucumber/scala/steps/ScStepDefinition.scala
@@ -28,7 +28,10 @@ class ScStepDefinition(scMethod: ScMethodCall) extends AbstractStepDefinition(sc
     "\\{float\\}" -> FLOAT_REGEXP,
     "\\{double\\}" -> FLOAT_REGEXP,
     "\\{word\\}" -> WORD_REGEXP,
-    "\\{string\\}" -> "(.*)"
+    "\\{string\\}" -> "(.*)",
+    "\\(([^\\s]*)\\)" -> "(?:$1)?", // Optional text
+    "\\{[^\\s]*\\}" -> "(.*)", // Parameter type
+    "([^\\s]*)/([^\\s]*)" -> "(?:$1|$2)" // Alternative text
   ).view.mapValues("(" + _ + ")")
 
   override def getVariableNames: util.List[String] = {
@@ -38,7 +41,8 @@ class ScStepDefinition(scMethod: ScMethodCall) extends AbstractStepDefinition(sc
   @Nullable
   override def getCucumberRegexFromElement(element: PsiElement): String = Try {
     scMethod match {
-      case mc: ScMethodCall => ScCucumberUtil.getStepRegex(mc).map(replaceParametersWithRegex).orNull
+      case mc: ScMethodCall =>
+        ScCucumberUtil.getStepRegex(mc).map(replaceParametersWithRegex).orNull
       case _ => null
     }
   }.getOrElse(null)

--- a/cucumber-scala/src/test/resources/testdata/resolveDirect/CustomTypes.scala
+++ b/cucumber-scala/src/test/resources/testdata/resolveDirect/CustomTypes.scala
@@ -1,0 +1,9 @@
+import io.cucumber.scala.ScalaDsl
+
+trait CustomTypes extends ScalaDsl {
+  ParameterType("speed", ".*\\s+km/h") { speed: String => Speed(speed.split(' ').head.toDouble) }
+  ParameterType("time", ".*\\s+h") { time: String => Time(time.split(' ').head.toDouble) }
+}
+
+case class Speed(kmPerHour: Double)
+case class Time(hours: Double)

--- a/cucumber-scala/src/test/resources/testdata/resolveDirect/StepDefinitions.scala
+++ b/cucumber-scala/src/test/resources/testdata/resolveDirect/StepDefinitions.scala
@@ -1,6 +1,6 @@
 import io.cucumber.scala.ScalaDsl
 
-class StepDefinitions extends ScalaDsl {
+class StepDefinitions extends ScalaDsl with CustomTypes {
   val calc = new Calculator
 
   When("^I add (\\d+) and (\\d+)$") { (arg1: Double, arg2: Double) =>
@@ -9,11 +9,10 @@ class StepDefinitions extends ScalaDsl {
     calc push "+"
   }
 
-  When("I sub (\\d+)" + " and " + "(\\d+)") {
-    (arg1: Double, arg2: Double) =>
-      calc push arg1
-      calc push arg2
-      calc push "-"
+  When("I sub (\\d+)" + " and " + "(\\d+)") { (arg1: Double, arg2: Double) =>
+    calc push arg1
+    calc push arg2
+    calc push "-"
   }
 
   When("I div " + (5 + 5) + " by " + (10 - 8)) {
@@ -22,15 +21,25 @@ class StepDefinitions extends ScalaDsl {
     calc push "/"
   }
 
-  And("nothing else") {
+  And("nothing else") {}
 
-  }
-
-  And("Some {int} parameter with {float}") {
-
-  }
+  And("Some {int} parameter with {float}") {}
 
   Then("^the result is ([+-]?\\d+)$") { expected: Double =>
     assertEquals(expected, calc.value, 0.001)
   }
+
+  When("I move at {speed} for {time}") { (arg1: Speed, arg2: Time) =>
+    calc push arg1.kmPerHour
+    calc push arg2.hours
+    calc push "*"
+  }
+
+  When("""I/We divide (\d+) by (\d+)""") { (arg1: Double, arg2: Double) =>
+    calc push arg1
+    calc push arg2
+    calc push "/"
+  }
+
+  When("""I do {int} nop(s)""") { (arg1: Int) => (0 to arg1).foreach { _ => /* NOP */ } }
 }

--- a/cucumber-scala/src/test/resources/testdata/resolveDirect/testcase.feature
+++ b/cucumber-scala/src/test/resources/testdata/resolveDirect/testcase.feature
@@ -13,3 +13,21 @@ Feature: Basic Arithmetic
     Then the result is 5
     And nothing else
     And Some 55 parameter with 3.14
+
+  Scenario: WeDividing
+    When We divide 10 by 2
+    Then the result is 5
+
+  Scenario: IDividing
+    When I divide 10 by 2
+    Then the result is 5
+
+  Scenario: Moving
+    When I move at 10m/s for 10m
+    Then the result is 100
+
+  Scenario: NOP
+    When I div 10 by 2
+    When I do 10 nops
+    When I do 10 nop
+    Then the result is 5

--- a/cucumber-scala/src/test/scala/com/github/vbmacher/intellij/cucumber/scala/resolve/StepResolveSpec.scala
+++ b/cucumber-scala/src/test/scala/com/github/vbmacher/intellij/cucumber/scala/resolve/StepResolveSpec.scala
@@ -6,8 +6,10 @@ import org.junit.runners.JUnit4
 
 @RunWith(classOf[JUnit4])
 class StepResolveSpec extends StepResolveSpecBase {
-  private val checkResolveDirect = singleResolve("resolveDirect/testcase.feature", "resolveDirect/StepDefinitions.scala") _
-  private val checkResolveIndirect = singleResolve("resolveIndirect/testcase.feature", "resolveIndirect/StepDefinitions.scala") _
+  private val checkResolveDirect =
+    singleResolve("resolveDirect/testcase.feature", "resolveDirect/StepDefinitions.scala") _
+  private val checkResolveIndirect =
+    singleResolve("resolveIndirect/testcase.feature", "resolveIndirect/StepDefinitions.scala") _
 
   @Test
   def testResolveSimple(): Unit = {
@@ -16,7 +18,7 @@ class StepResolveSpec extends StepResolveSpecBase {
 
   @Test
   def testWithParameters(): Unit = {
-    checkResolveDirect("I add 4 and 5")  // does not include "When", because test regex is within ^$
+    checkResolveDirect("I add 4 and 5") // does not include "When", because test regex is within ^$
   }
 
   @Test
@@ -35,8 +37,26 @@ class StepResolveSpec extends StepResolveSpecBase {
   }
 
   @Test
+  def testCustomTypeIsSupported(): Unit = {
+    checkResolveDirect("I move at 10km/h for 1h")
+  }
+
+  @Test
+  def testAlternativeTextSupport(): Unit = {
+    checkResolveDirect("We divide 10 by 1")
+    checkResolveDirect("I divide 10 by 1")
+  }
+
+  @Test
+  def testOptionalTextSupport(): Unit = {
+    checkResolveDirect("I do 10 nop")
+    checkResolveDirect("I do 10 nops")
+  }
+
+  @Test
   def testResolveMultipleDefinitions(): Unit = {
-    multiResolve(2,
+    multiResolve(
+      expectedCount = 2,
       "resolveMultiple/testcase.feature",
       "resolveMultiple/StepDefs1.scala",
       "resolveMultiple/StepDefs2.scala"

--- a/example/src/main/scala/Calculator.scala
+++ b/example/src/main/scala/Calculator.scala
@@ -1,4 +1,3 @@
-
 import scala.collection.mutable
 import scala.language.implicitConversions
 
@@ -7,9 +6,9 @@ sealed trait Arg
 case class Op(value: String) extends Arg
 case class Val(value: Double) extends Arg
 
-object Arg{
-  implicit def op(s:String):Op = Op(s)
-  implicit def value(v:Double):Val = Val(v)
+object Arg {
+  implicit def op(s: String): Op = Op(s)
+  implicit def value(v: Double): Val = Val(v)
 }
 
 class Calculator {

--- a/example/src/test/resources/cucumber/examples/scalacalculator/basic_arithmetic.feature
+++ b/example/src/test/resources/cucumber/examples/scalacalculator/basic_arithmetic.feature
@@ -16,3 +16,31 @@ Feature: Basic Arithmetic
   Scenario: Dividing
     When I div 10 by 2
     Then the result is 5
+
+  Scenario: WeDividing
+    When We divide 10 by 2
+    Then the result is 5
+
+  Scenario: IDividing
+    When I divide 10 by 2
+    Then the result is 5
+
+  Scenario: Moving
+    #sadly suggests both, but its better then no suggestion
+    # - "I move at {speed} for {time}"
+    # - "I move at {speed-m-s} for {time-s}"
+    When I move at 10km/h for 10h
+    Then the result is 100
+
+  Scenario: Moving meters Per second
+    #sadly suggests both, but its better then no suggestion
+    # - "I move at {speed} for {time}"
+    # - "I move at {speed-m-s} for {time-s}"
+    When I move at 10m/s for 10s
+    Then the result is 100
+
+  Scenario: NOP
+    When I div 10 by 2
+    When I do 10 nops
+    When I do 10 nop
+    Then the result is 5

--- a/example/src/test/scala/CustomTypes.scala
+++ b/example/src/test/scala/CustomTypes.scala
@@ -1,0 +1,12 @@
+import io.cucumber.scala.ScalaDsl
+
+trait CustomTypes extends ScalaDsl {
+  ParameterType("speed", ".*\\s+km/h") { speed: String => Speed(speed.split(' ').head.toDouble) }
+  ParameterType("time", ".*\\s+h") { time: String => Time(time.split(' ').head.toDouble) }
+
+  ParameterType("speed-m-s", ".*\\s+m/s") { speed: String => Speed(speed.split(' ').head.toDouble) }
+  ParameterType("time-s", ".*\\s+s") { time: String => Time(time.split(' ').head.toDouble) }
+}
+
+case class Speed(kmPerHour: Double)
+case class Time(hours: Double)

--- a/example/src/test/scala/StepDefinitions.scala
+++ b/example/src/test/scala/StepDefinitions.scala
@@ -1,16 +1,15 @@
-class StepDefinitions extends StepDefinitionsTrait {
+class StepDefinitions extends StepDefinitionsTrait with CustomTypes {
 
-  When("""^I add (\d+) and (\d+)$"""){ (arg1: Double, arg2: Double) =>
+  When("""^I add (\d+) and (\d+)$""") { (arg1: Double, arg2: Double) =>
     calc push arg1
     calc push arg2
     calc push "+"
   }
 
-  When("I sub (\\d+)" + " and " + "(\\d+)") {
-    (arg1: Double, arg2: Double) =>
-      calc push arg1
-      calc push arg2
-      calc push "-"
+  When("I sub (\\d+)" + " and " + "(\\d+)") { (arg1: Double, arg2: Double) =>
+    calc push arg1
+    calc push arg2
+    calc push "-"
   }
 
   When("I div " + (5 + 5) + " by " + (10 - 8)) {
@@ -18,4 +17,24 @@ class StepDefinitions extends StepDefinitionsTrait {
     calc push 2.0
     calc push "/"
   }
+
+  When("I move at {speed} for {time}") { (arg1: Speed, arg2: Time) =>
+    calc push arg1.kmPerHour
+    calc push arg2.hours
+    calc push "*"
+  }
+
+  When("I move at {speed-m-s} for {time-s}") { (arg1: Speed, arg2: Time) =>
+    calc push arg1.kmPerHour
+    calc push arg2.hours
+    calc push "*"
+  }
+
+  When("""I/We divide (\d+) by (\d+)""") { (arg1: Double, arg2: Double) =>
+    calc push arg1
+    calc push arg2
+    calc push "*"
+  }
+
+  When("""I do {int} nop(s)""") { (arg1: Int) => (0 to arg1).foreach { _ => calc push "NOP" } }
 }


### PR DESCRIPTION
So this does a very simple thing if it can't find a type it will just tries (.*) which atleast fixes the navigation to your statements.
But doesn't allow to automaticly resolve step 'overloading'.   

Add support for CustomTypes
Add support for alternative values
Add support for optional text fields